### PR TITLE
Add symfony 4+ support

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,125 +8,144 @@
 
     <services>
 
-        <service id="goetas_webservices.soap_client.metadata_loader.dev" public="true"
-                 class="GoetasWebservices\SoapServices\SoapClient\Metadata\Loader\DevMetadataLoader">
+        <service id="goetas_webservices.soap_client.metadata_loader.dev"
+                 class="GoetasWebservices\SoapServices\SoapClient\Metadata\Loader\DevMetadataLoader"
+                 public="true">
             <argument type="service" id="goetas_webservices.soap_client.metadata.generator"/>
             <argument type="service" id="goetas_webservices.wsdl2php.soap_reader"/>
             <argument type="service" id="goetas_webservices.wsdl2php.wsdl_reader"/>
         </service>
 
-        <service id="goetas_webservices.soap_client.metadata_loader.array" public="false"
-                 class="GoetasWebservices\SoapServices\SoapClient\Metadata\Loader\ArrayMetadataLoader">
+        <service id="goetas_webservices.soap_client.metadata_loader.array"
+                 class="GoetasWebservices\SoapServices\SoapClient\Metadata\Loader\ArrayMetadataLoader"
+                 public="true">
             <argument>%goetas_webservices.soap_client.metadata%</argument>
         </service>
 
-        <service id="goetas_webservices.soap_client.metadata.generator" public="false"
-                 class="GoetasWebservices\SoapServices\SoapClient\Metadata\Generator\MetadataGenerator">
+        <service id="goetas_webservices.soap_client.metadata.generator"
+                 class="GoetasWebservices\SoapServices\SoapClient\Metadata\Generator\MetadataGenerator"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.naming_convention" type="service"/>
             <argument type="collection"/>
         </service>
 
-        <service id="goetas_webservices.xsd2php.naming_convention.short" public="false"
-                 class="GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy"/>
-        <service id="goetas_webservices.xsd2php.naming_convention.long" public="false"
-                 class="GoetasWebservices\Xsd\XsdToPhp\Naming\LongNamingStrategy"/>
+        <service id="goetas_webservices.xsd2php.naming_convention.short"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy"
+                 public="true"/>
+        <service id="goetas_webservices.xsd2php.naming_convention.long"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Naming\LongNamingStrategy"
+                 public="true"/>
 
+        <service id="goetas_webservices.soap_client.metadata_reader" synthetic="true" public="true"/>
 
-        <service id="goetas_webservices.soap_client.metadata_reader" synthetic="true" public="true"></service>
-
-        <service id="logger" public="true" class="Psr\Log\NullLogger"></service>
+        <service id="logger" public="true" class="Psr\Log\NullLogger"/>
 
         <service id="goetas_webservices.soap_client.stub.client_generator"
-                 class="GoetasWebservices\SoapServices\SoapClient\StubGeneration\ClientStubGenerator">
+                 class="GoetasWebservices\SoapServices\SoapClient\StubGeneration\ClientStubGenerator"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.converter.php" type="service"/>
             <argument id="goetas_webservices.xsd2php.naming_convention" type="service"/>
             <argument type="collection"/>
         </service>
 
-
-        <service id="goetas_webservices.xsd2php.schema_reader" public="true"
-                 class="GoetasWebservices\XML\XSDReader\SchemaReader">
+        <service id="goetas_webservices.xsd2php.schema_reader"
+                 class="GoetasWebservices\XML\XSDReader\SchemaReader"
+                 public="true">
         </service>
 
-        <service synthetic="true" public="false" id="goetas_webservices.xsd2php.naming_convention"/>
+        <service synthetic="true" public="true" id="goetas_webservices.xsd2php.naming_convention"/>
         <service synthetic="true" abstract="true" id="logger"/>
 
-
-        <service id="goetas_webservices.xsd2php.path_generator.php.psr4" public="false"
-                 class="GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\Psr4PathGenerator"></service>
-        <service id="goetas_webservices.xsd2php.path_generator.jms.psr4" public="false"
-                 class="GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator\Psr4PathGenerator"></service>
+        <service id="goetas_webservices.xsd2php.path_generator.php.psr4"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Php\PathGenerator\Psr4PathGenerator"
+                 public="false"/>
+        <service id="goetas_webservices.xsd2php.path_generator.jms.psr4"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Jms\PathGenerator\Psr4PathGenerator"
+                 public="false"/>
 
         <service id="goetas_webservices.soap_client.stub.class_writer"
-                 class="GoetasWebservices\SoapServices\SoapClient\StubGeneration\ClientStubGenerator">
+                 class="GoetasWebservices\SoapServices\SoapClient\StubGeneration\ClientStubGenerator"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.converter.php" type="service"/>
             <argument id="goetas_webservices.xsd2php.naming_convention" type="service"/>
             <argument>%goetas_webservices.soap_client.unwrap_returns%</argument>
             <argument type="collection"/>
         </service>
 
-
-        <service id="goetas_webservices.xsd2php.writer.php" class="GoetasWebservices\Xsd\XsdToPhp\Writer\PHPWriter">
+        <service id="goetas_webservices.xsd2php.writer.php"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Writer\PHPWriter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.class_writer.php" type="service"/>
             <argument id="goetas_webservices.xsd2php.php.class_generator" type="service"/>
             <argument id="logger" type="service"/>
         </service>
 
         <service id="goetas_webservices.xsd2php.class_writer.php"
-                 class="GoetasWebservices\Xsd\XsdToPhp\Writer\PHPClassWriter">
+                 class="GoetasWebservices\Xsd\XsdToPhp\Writer\PHPClassWriter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.path_generator.php" type="service"/>
             <argument id="logger" type="service"/>
         </service>
 
         <service id="goetas_webservices.xsd2php.php.class_generator"
-                 class="GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator"></service>
+                 class="GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator"
+                 public="true"/>
 
-        <service id="goetas_webservices.xsd2php.writer.jms" class="GoetasWebservices\Xsd\XsdToPhp\Writer\JMSWriter">
+        <service id="goetas_webservices.xsd2php.writer.jms"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Writer\JMSWriter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.path_generator.jms" type="service"/>
             <argument id="logger" type="service"/>
         </service>
 
         <service id="goetas_webservices.wsdl2php.event_dispatcher"
-                 class="Symfony\Component\EventDispatcher\EventDispatcher">
+                 class="Symfony\Component\EventDispatcher\EventDispatcher"
+                 public="true">
             <call method="addSubscriber">
                 <argument type="service" id="goetas_webservices.wsdl2php.soap_reader"/>
             </call>
         </service>
 
-        <service id="goetas_webservices.wsdl2php.soap_reader" class="GoetasWebservices\XML\SOAPReader\SoapReader"/>
+        <service id="goetas_webservices.wsdl2php.soap_reader"
+                 class="GoetasWebservices\XML\SOAPReader\SoapReader"
+                 public="true"/>
 
         <service id="goetas_webservices.wsdl2php.wsdl_reader"
-                 class="GoetasWebservices\XML\WSDLReader\DefinitionsReader">
+                 class="GoetasWebservices\XML\WSDLReader\DefinitionsReader"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.schema_reader" type="service"/>
             <argument id="goetas_webservices.wsdl2php.event_dispatcher" type="service"/>
         </service>
 
         <service id="goetas_webservices.wsdl2php.converter.php"
-                 class="GoetasWebservices\WsdlToPhp\Generation\PhpSoapConverter">
+                 class="GoetasWebservices\WsdlToPhp\Generation\PhpSoapConverter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.converter.php" type="service"/>
         </service>
 
-
         <service id="goetas_webservices.wsdl2php.converter.jms"
-                 class="GoetasWebservices\WsdlToPhp\Generation\JmsSoapConverter">
+                 class="GoetasWebservices\WsdlToPhp\Generation\JmsSoapConverter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.converter.jms" type="service"/>
         </service>
 
-
-        <service id="goetas_webservices.xsd2php.converter.php" class="GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter">
+        <service id="goetas_webservices.xsd2php.converter.php"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.naming_convention" type="service"/>
             <call method="setLogger">
-                <argument type="service" id="logger"></argument>
+                <argument type="service" id="logger"/>
             </call>
         </service>
 
-        <service id="goetas_webservices.xsd2php.converter.jms" class="GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter">
+        <service id="goetas_webservices.xsd2php.converter.jms"
+                 class="GoetasWebservices\Xsd\XsdToPhp\Jms\YamlConverter"
+                 public="true">
             <argument id="goetas_webservices.xsd2php.naming_convention" type="service"/>
             <call method="setLogger">
-                <argument type="service" id="logger"></argument>
+                <argument type="service" id="logger"/>
             </call>
         </service>
-
 
     </services>
 </container>


### PR DESCRIPTION
In Symfony 4+, services are private by default. Project and dependencies could be refactored to use dependency injection and autowiring, but this would require much more work than making most services public.

Close #40