### PR TITLE
Bumb dependencies to be compatible with php-http/httplug 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php": "^5.6|^7.0",
 
     "psr/http-message": "^1.0",
-    "php-http/httplug": "^1.0",
+    "php-http/httplug": "^1.0|^2.0",
     "php-http/discovery": "^1.0",
     "php-http/message-factory": "^1.0.2",
     "symfony/dependency-injection": "^2.4|^3.0|^4.0",
@@ -27,7 +27,7 @@
     "goetas-webservices/wsdl2php": "^0.4",
     "goetas-webservices/wsdl-reader": "^0.3.1",
 
-    "php-http/guzzle6-adapter": "^1.0",
+    "php-http/guzzle6-adapter": "^1.0|^2.0",
     "php-http/message": "^1.0"
   },
   "autoload": {


### PR DESCRIPTION
Setup composer constraints so `php-http/httplug` v2.0 can be used.

![image](https://user-images.githubusercontent.com/55820/82878388-b3ffe400-9f3b-11ea-8e29-16495b24a5bd.png)

See: 
https://github.com/php-http/httplug/blob/master/CHANGELOG.md#200---2018-10-31