### PR TITLE
Add support for jms/serializer 2.x/3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "doctrine/instantiator": "^1.0.3",
 
     "goetas-webservices/xsd2php-runtime": "^0.2.2",
-    "jms/serializer": "^1.6"
+    "jms/serializer": "^1.6|^2.0|^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8|^5.0",

--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -77,5 +77,7 @@ class Generate extends Command
         $classDefinitions = $clientStubGenerator->generate($portTypes);
         $classWriter = $debugContainer->get('goetas_webservices.xsd2php.class_writer.php');
         $classWriter->write($classDefinitions);
+
+        return 0;
     }
 }

--- a/src/Result/ResultCreator.php
+++ b/src/Result/ResultCreator.php
@@ -2,7 +2,10 @@
 
 namespace GoetasWebservices\SoapServices\SoapClient\Result;
 
+use GoetasWebservices\SoapServices\SoapClient\SerializerUtils;
 use JMS\Serializer\Serializer;
+use Metadata\MetadataFactoryInterface;
+use Metadata\PropertyMetadata;
 
 class ResultCreator implements ResultCreatorInterface
 {
@@ -18,20 +21,26 @@ class ResultCreator implements ResultCreatorInterface
         $this->unwrap = $unwrap;
     }
 
+    private function getPropertyValue($propertyMetadata, $object) {
+        $reflectionProperty = new \ReflectionProperty($propertyMetadata->class, $propertyMetadata->name);
+        $reflectionProperty->setAccessible(true);
+        return $reflectionProperty->getValue($object);
+    }
+
     public function prepareResult($object, array $output)
     {
         if (!count($output['parts'])) {
             return null;
         }
-        $factory = $this->serializer->getMetadataFactory();
+        $factory = SerializerUtils::getMetadataFactory($this->serializer);
 
         $classMetadata = $factory->getMetadataForClass($output['message_fqcn']);
         $bodyMetadata = $classMetadata->propertyMetadata['body'];
         $bodyClassMetadata = $factory->getMetadataForClass($bodyMetadata->type['name']);
-        $body = $bodyMetadata->getValue($object);
+        $body = $this->getPropertyValue($bodyMetadata, $object);
         $parts = [];
         foreach ($bodyClassMetadata->propertyMetadata as $propertyMetadata) {
-            $parts[$propertyMetadata->name] = $propertyMetadata->getValue($body);
+            $parts[$propertyMetadata->name] = $this->getPropertyValue($propertyMetadata, $body);
         }
         if (count($output['parts']) > 1) {
             return $parts;
@@ -47,7 +56,7 @@ class ResultCreator implements ResultCreatorInterface
                         return null;
                     }
                     $propertyMetadata = reset($propClassMetadata->propertyMetadata);
-                    return $propertyMetadata->getValue(reset($parts));
+                    return $this->getPropertyValue($propertyMetadata, reset($parts));
                 }
             }
             return reset($parts);

--- a/src/SerializerUtils.php
+++ b/src/SerializerUtils.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GoetasWebservices\SoapServices\SoapClient;
+
+use JMS\Serializer\Serializer;
+use Metadata\MetadataFactory;
+
+class SerializerUtils
+{
+    /**
+     * Get metadata factory from serializer, with any JMS Serializer version.
+     *
+     * @param $serializer Serializer
+     * @return MetadataFactory
+     */
+    public static function getMetadataFactory($serializer)
+    {
+        if (method_exists($serializer, "getMetadataFactory")) {
+            // JMS Serializer 1.x
+            return $serializer->getMetadataFactory();
+        } else {
+            // JMS Serializer 2.x & 3.x
+            $reflectionProperty = new \ReflectionProperty(get_class($serializer), 'factory');
+            $reflectionProperty->setAccessible(true);
+            return $reflectionProperty->getValue($serializer);
+        }
+    }
+}


### PR DESCRIPTION
I need to use some reflection to grab MetadataFactory from Serializer instance. I'm not sure it's the best way to do it, but can't find another way around without breaking everything.

Same for getValue/setValue with have been removed from PropertyMetadata, maybe there's something available in the dependencies to do that.

Note that unit tests have been checked on 1.x, 2.x and 3.x.