### PR TITLE
Pass soap context to serializer

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -17,6 +17,7 @@ use GoetasWebservices\SoapServices\SoapEnvelope;
 use Http\Client\Exception\HttpException;
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory;
+use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -76,7 +77,14 @@ class Client
         $soapOperation = $this->findOperation($functionName, $this->serviceDefinition);
         $message = $this->argumentsReader->readArguments($args, $soapOperation['input']);
 
-        $xmlMessage = $this->serializer->serialize($message, 'xml');
+        $xmlMessage = $this->serializer->serialize(
+            $message,
+            'xml',
+            (new SerializationContext())
+                ->setAttribute('soapAction', $soapOperation['action'])
+                ->setAttribute('soapEndpoint', $this->serviceDefinition['endpoint'])
+        );
+
         $headers = $this->buildHeaders($soapOperation);
         $this->requestMessage = $request = $this->messageFactory->createRequest('POST', $this->serviceDefinition['endpoint'], $headers, $xmlMessage);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -146,7 +146,7 @@ class Client
 
     protected function findFaultClass(ResponseInterface $response)
     {
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/soap+xml') === 0) {
+        if (strpos($response->getHeaderLine('Content-Type'), 'application/soap+xml') !== false) {
             return Fault12::class;
         } else {
             return Fault11::class;

--- a/tests/Client/ClientRequestResponsesTest.php
+++ b/tests/Client/ClientRequestResponsesTest.php
@@ -34,10 +34,6 @@ class ClientRequestResponsesTest extends \PHPUnit_Framework_TestCase
      * @var Generator
      */
     protected static $generator;
-    /**
-     * @var Server
-     */
-    protected static $server;
 
     /**
      * @var \GuzzleHttp\Handler\MockHandler


### PR DESCRIPTION
Follow-up on https://github.com/goetas-webservices/soap-client/pull/33:

I have reduced the number of code changes and reverted the refactor, it made the PR unclear.

I have now added a test for checking if the context parameters are correctly passed to the serializer handlers.