### PR TITLE
Pass soapEndpoint and soapAction attributes on the serializer context

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -131,6 +131,9 @@ class Client
 
         $bag = new HeadersOutgoing($headers);
         $context = SerializationContext::create()->setAttribute('headers_outgoing', $bag);
+        $context->setAttribute('soapAction', $soapOperation['action']);
+        $context->setAttribute('soapEndpoint', $this->serviceDefinition['endpoint']);
+
         $xmlMessage = $this->serializer->serialize($message, 'xml', $context);
 
         $requestMessage = $this->createRequestMessage($xmlMessage, $soapOperation);

--- a/src/Client.php
+++ b/src/Client.php
@@ -131,7 +131,7 @@ class Client
 
         $bag = new HeadersOutgoing($headers);
         $context = SerializationContext::create()->setAttribute('headers_outgoing', $bag);
-        $context->setAttribute('soapAction', $soapOperation['action']);
+        $context->setAttribute('soapOperation', $soapOperation);
         $context->setAttribute('soapEndpoint', $this->serviceDefinition['endpoint']);
 
         $xmlMessage = $this->serializer->serialize($message, 'xml', $context);

--- a/tests/Client/Client12RequestResponsesTest.php
+++ b/tests/Client/Client12RequestResponsesTest.php
@@ -406,12 +406,15 @@ class Client12RequestResponsesTest extends RequestResponsesTest
         $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, \Ex\SoapEnvelope12\Messages\GetSimpleInput::class, 'xml',
             function($visitor, \Ex\SoapEnvelope12\Messages\GetSimpleInput $obj, array $type, Context $context) {
 
-                self::assertTrue($context->hasAttribute('soapEndpoint'), 'The "soapEndpoint" attribute was not found on the context object');
-                self::assertEquals('http://www.example.org/12', $context->getAttribute('soapEndpoint'));
+                $this->assertTrue($context->hasAttribute('soapEndpoint'), 'The "soapEndpoint" attribute was not found on the context object');
+                $this->assertEquals('http://www.example.org/12', $context->getAttribute('soapEndpoint'));
 
-                self::assertTrue($context->hasAttribute('soapOperation'), 'The "soapOperation" attribute was not found on the context object');
-                self::assertIsArray($context->getAttribute('soapOperation'));
-                self::assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapOperation')['action']);
+                $this->assertTrue($context->hasAttribute('soapOperation'), 'The "soapOperation" attribute was not found on the context object');
+                $this->assertTrue(
+                    is_array($context->getAttribute('soapOperation')),
+                    'The "soapOperation" attribute is not of type array, but '.gettype($context->getAttribute('soapOperation'))
+                );
+                $this->assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapOperation')['action']);
 
                 throw new SerializerHandlerAssertionsWereExecuted('Stop serialization, test has finished');
             }
@@ -420,7 +423,7 @@ class Client12RequestResponsesTest extends RequestResponsesTest
         $client = $this->getClient();
 
         // Assert that subscribing handler with assertions was executed
-        self::expectException(SerializerHandlerAssertionsWereExecuted::class);
+        $this->expectException(SerializerHandlerAssertionsWereExecuted::class);
 
         $client->getSimple('foo');
     }

--- a/tests/Client/Client12RequestResponsesTest.php
+++ b/tests/Client/Client12RequestResponsesTest.php
@@ -14,7 +14,6 @@ use GoetasWebservices\SoapServices\Metadata\Headers\Header;
 use GoetasWebservices\SoapServices\Metadata\Loader\DevMetadataLoader;
 use GoetasWebservices\SoapServices\SoapClient\Client;
 use GoetasWebservices\SoapServices\SoapClient\Exception\Fault12Exception;
-use GoetasWebservices\WsdlToPhp\Tests\Generator;
 use GoetasWebservices\XML\SOAPReader\SoapReader;
 use GoetasWebservices\XML\WSDLReader\DefinitionsReader;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
@@ -405,26 +404,18 @@ class Client12RequestResponsesTest extends RequestResponsesTest
 
     public function testSerializerContextParametersAreAdded()
     {
-        // Override serializer with a custom handler for asserting the context parameters
-        $handlers = function (HandlerRegistryInterface $h) {
-            $h->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, \Ex\SoapEnvelope12\Messages\GetSimpleInput::class, 'xml',
-                function($visitor, \Ex\SoapEnvelope12\Messages\GetSimpleInput $obj, array $type, Context $context) {
+        $this->handlerRegistry->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, \Ex\SoapEnvelope12\Messages\GetSimpleInput::class, 'xml',
+            function($visitor, \Ex\SoapEnvelope12\Messages\GetSimpleInput $obj, array $type, Context $context) {
 
-                    self::assertTrue($context->hasAttribute('soapEndpoint'), 'The "soapEndpoint" attribute was not found on the context object');
-                    self::assertTrue($context->hasAttribute('soapAction'), 'The "soapAction" attribute was not found on the context object');
-                    self::assertEquals('http://www.example.org/12', $context->getAttribute('soapEndpoint'));
-                    self::assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapAction'));
+                self::assertTrue($context->hasAttribute('soapEndpoint'), 'The "soapEndpoint" attribute was not found on the context object');
+                self::assertTrue($context->hasAttribute('soapAction'), 'The "soapAction" attribute was not found on the context object');
+                self::assertEquals('http://www.example.org/12', $context->getAttribute('soapEndpoint'));
+                self::assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapAction'));
 
-                    throw new SerializerHandlerAssertionsWereExecuted('Stop serialization, test has finished');
-                });
-        };
-        $ref = new \ReflectionClass(Fault::class);
-        $serializer = self::$generator->buildSerializer($handlers, [
-            'GoetasWebservices\SoapServices\Metadata\Envelope\SoapEnvelope12' => dirname($ref->getFileName()) . '/../../../Resources/metadata/jms12',
-            'GoetasWebservices\SoapServices\Metadata\Envelope\SoapEnvelope' => dirname($ref->getFileName()) . '/../../../Resources/metadata/jms',
-        ]);
+                throw new SerializerHandlerAssertionsWereExecuted('Stop serialization, test has finished');
+            }
+        );
 
-        $this->factory->setSerializer($serializer);
         $client = $this->getClient();
 
         // Assert that subscribing handler with assertions was executed

--- a/tests/Client/Client12RequestResponsesTest.php
+++ b/tests/Client/Client12RequestResponsesTest.php
@@ -20,7 +20,6 @@ use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GuzzleHttp\Psr7\Response;
 use JMS\Serializer\Context;
 use JMS\Serializer\GraphNavigator;
-use JMS\Serializer\Handler\HandlerRegistryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Client12RequestResponsesTest extends RequestResponsesTest
@@ -408,9 +407,11 @@ class Client12RequestResponsesTest extends RequestResponsesTest
             function($visitor, \Ex\SoapEnvelope12\Messages\GetSimpleInput $obj, array $type, Context $context) {
 
                 self::assertTrue($context->hasAttribute('soapEndpoint'), 'The "soapEndpoint" attribute was not found on the context object');
-                self::assertTrue($context->hasAttribute('soapAction'), 'The "soapAction" attribute was not found on the context object');
                 self::assertEquals('http://www.example.org/12', $context->getAttribute('soapEndpoint'));
-                self::assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapAction'));
+
+                self::assertTrue($context->hasAttribute('soapOperation'), 'The "soapOperation" attribute was not found on the context object');
+                self::assertIsArray($context->getAttribute('soapOperation'));
+                self::assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapOperation')['action']);
 
                 throw new SerializerHandlerAssertionsWereExecuted('Stop serialization, test has finished');
             }

--- a/tests/Client/Client12RequestResponsesTest.php
+++ b/tests/Client/Client12RequestResponsesTest.php
@@ -14,10 +14,14 @@ use GoetasWebservices\SoapServices\Metadata\Headers\Header;
 use GoetasWebservices\SoapServices\Metadata\Loader\DevMetadataLoader;
 use GoetasWebservices\SoapServices\SoapClient\Client;
 use GoetasWebservices\SoapServices\SoapClient\Exception\Fault12Exception;
+use GoetasWebservices\WsdlToPhp\Tests\Generator;
 use GoetasWebservices\XML\SOAPReader\SoapReader;
 use GoetasWebservices\XML\WSDLReader\DefinitionsReader;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\ShortNamingStrategy;
 use GuzzleHttp\Psr7\Response;
+use JMS\Serializer\Context;
+use JMS\Serializer\GraphNavigator;
+use JMS\Serializer\Handler\HandlerRegistryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Client12RequestResponsesTest extends RequestResponsesTest
@@ -398,4 +402,36 @@ class Client12RequestResponsesTest extends RequestResponsesTest
             '), $detail->asXML());
         }
     }
+
+    public function testSerializerContextParametersAreAdded()
+    {
+        // Override serializer with a custom handler for asserting the context parameters
+        $handlers = function (HandlerRegistryInterface $h) {
+            $h->registerHandler(GraphNavigator::DIRECTION_SERIALIZATION, \Ex\SoapEnvelope12\Messages\GetSimpleInput::class, 'xml',
+                function($visitor, \Ex\SoapEnvelope12\Messages\GetSimpleInput $obj, array $type, Context $context) {
+
+                    self::assertTrue($context->hasAttribute('soapEndpoint'), 'The "soapEndpoint" attribute was not found on the context object');
+                    self::assertTrue($context->hasAttribute('soapAction'), 'The "soapAction" attribute was not found on the context object');
+                    self::assertEquals('http://www.example.org/12', $context->getAttribute('soapEndpoint'));
+                    self::assertEquals('http://www.example.org/test/getSimple', $context->getAttribute('soapAction'));
+
+                    throw new SerializerHandlerAssertionsWereExecuted('Stop serialization, test has finished');
+                });
+        };
+        $ref = new \ReflectionClass(Fault::class);
+        $serializer = self::$generator->buildSerializer($handlers, [
+            'GoetasWebservices\SoapServices\Metadata\Envelope\SoapEnvelope12' => dirname($ref->getFileName()) . '/../../../Resources/metadata/jms12',
+            'GoetasWebservices\SoapServices\Metadata\Envelope\SoapEnvelope' => dirname($ref->getFileName()) . '/../../../Resources/metadata/jms',
+        ]);
+
+        $this->factory->setSerializer($serializer);
+        $client = $this->getClient();
+
+        // Assert that subscribing handler with assertions was executed
+        self::expectException(SerializerHandlerAssertionsWereExecuted::class);
+
+        $client->getSimple('foo');
+    }
 }
+
+class SerializerHandlerAssertionsWereExecuted extends \Exception {};

--- a/tests/Client/RequestResponsesTest.php
+++ b/tests/Client/RequestResponsesTest.php
@@ -58,6 +58,11 @@ abstract class RequestResponsesTest extends TestCase
      */
     protected $factory;
 
+    /**
+     * @var HandlerRegistryInterface
+     */
+    protected $handlerRegistry;
+
     public static function setUpBeforeClass(): void
     {
         self::$generator = new Generator(self::$namespaces, [], __DIR__ . '/tmp');
@@ -81,8 +86,9 @@ abstract class RequestResponsesTest extends TestCase
             $d->addSubscriber($headerHandler);
         };
 
-        $handlers = static function (HandlerRegistryInterface $h) use ($headerHandler): void {
+        $handlers = function (HandlerRegistryInterface $h) use ($headerHandler): void {
             $h->registerSubscribingHandler($headerHandler);
+            $this->handlerRegistry = $h;
         };
 
         $serializer = self::$generator->buildSerializer($handlers, [


### PR DESCRIPTION
Follow-up on #33:

I have reduced the number of code changes and reverted the refactor, it made the PR unclear.

I have now added a test for checking if the context parameters are correctly passed to the serializer handlers.