### PR TITLE
Add option to generate strict types in method signatures through xsd2php

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,6 +26,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+            ->booleanNode('strict_types')->defaultFalse()->end()
             ->arrayNode('alternative_endpoints')->fixXmlConfig('alternative_endpoint')
             ->prototype('array')
             ->prototype('scalar')

--- a/src/DependencyInjection/SoapClientExtension.php
+++ b/src/DependencyInjection/SoapClientExtension.php
@@ -23,6 +23,7 @@ class SoapClientExtension extends Extension
 
         $container->setParameter('goetas_webservices.soap.config', $config);
         $container->setParameter('goetas_webservices.soap.unwrap_returns', $config['unwrap_returns']);
+        $container->setParameter('goetas_webservices.soap.strict_types', $config['strict_types']);
 
         $xml = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $xml->load('services.xml');

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -90,7 +90,9 @@
 
         <service id="goetas_webservices.xsd2php.php.class_generator"
                  class="GoetasWebservices\Xsd\XsdToPhp\Php\ClassGenerator"
-                 public="true"/>
+                 public="true">
+            <argument>%goetas_webservices.soap.strict_types%</argument>
+        </service>
 
         <service id="goetas_webservices.xsd2php.writer.jms"
                  class="GoetasWebservices\Xsd\XsdToPhp\Writer\JMSWriter"


### PR DESCRIPTION
This config option is to enable strict type generation through xsd2php, as introduced in https://github.com/goetas-webservices/xsd2php/commit/a3fe60d58ccd59194603e60804fe6adff7b51ab4