### PR TITLE
Remove laminas-zendframework-bridge dependency (Fixes #69)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "goetas-webservices/soap-reader": "^0.3.3",
     "goetas-webservices/xsd2php": "^0.4.7",
     "laminas/laminas-code": "^4.8",
-    "laminas/laminas-zendframework-bridge": "^1.7",
     "doctrine/inflector": "^2.0"
   },
   "require-dev": {

--- a/src/StubGeneration/ClientStubGenerator.php
+++ b/src/StubGeneration/ClientStubGenerator.php
@@ -14,8 +14,8 @@ use GoetasWebservices\XML\WSDLReader\Wsdl\PortType;
 use GoetasWebservices\Xsd\XsdToPhp\Naming\NamingStrategy;
 use GoetasWebservices\Xsd\XsdToPhp\Php\PhpConverter;
 use GoetasWebservices\Xsd\XsdToPhp\Php\Structure\PHPClass;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\DocBlockGenerator;
 
 class ClientStubGenerator
 {

--- a/src/StubGeneration/Tag/MethodTag.php
+++ b/src/StubGeneration/Tag/MethodTag.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 namespace GoetasWebservices\SoapServices\SoapClient\StubGeneration\Tag;
 
 use GoetasWebservices\SoapServices\SoapClient\StubGeneration\Tag\ParamTag as SoapParamTag;
-use Zend\Code\Generator\DocBlock\Tag\MethodTag as BaseMethodTag;
-use Zend\Code\Generator\DocBlock\Tag\ParamTag;
+use Laminas\Code\Generator\DocBlock\Tag\MethodTag as BaseMethodTag;
+use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
 
 class MethodTag extends BaseMethodTag
 {

--- a/src/StubGeneration/Tag/ParamTag.php
+++ b/src/StubGeneration/Tag/ParamTag.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace GoetasWebservices\SoapServices\SoapClient\StubGeneration\Tag;
 
-use Zend\Code\Generator\DocBlock\Tag\ParamTag as ParamTagTag;
+use Laminas\Code\Generator\DocBlock\Tag\ParamTag as ParamTagTag;
 
 class ParamTag extends ParamTagTag
 {


### PR DESCRIPTION
This pull request removes the abandoned laminas-zendframework-bridge dependency. It's no longer needed.

All phpunit tests still work without any problem.

That's my part done. Now we need a new release tagged.

Thanks